### PR TITLE
Force the copy over existing files when using the manifest.

### DIFF
--- a/ansys/tools/repo_sync/repo_sync.py
+++ b/ansys/tools/repo_sync/repo_sync.py
@@ -128,6 +128,7 @@ def synchronize(
                     os.path.join(origin_directory, protos_path),
                     os.path.join(os.getcwd(), output_path),
                     ignore=shutil.ignore_patterns(*prohibited_extensions),
+                    dirs_exist_ok=True,
                 )
 
         else:


### PR DESCRIPTION
Force the copy over existing files when using the manifest.