### PR TITLE
feat: allow for random test branch names

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,6 @@
 # the repo. Unless a later match takes precedence,
 # they will be requested for review when someone opens a pull request.
 *       @ansys/pyansys-core
+
+# Test folder should be ignored
+/src/ansys/api/test

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -47,7 +47,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: [smoke-tests]
     strategy:
-      max-parallel: 1 # Changes are performed to the repo on execution
       matrix:
        os: [ubuntu-latest, windows-latest]
        python-version: ['3.8', '3.11']

--- a/src/ansys/tools/repo_sync/__main__.py
+++ b/src/ansys/tools/repo_sync/__main__.py
@@ -45,8 +45,23 @@ from .repo_sync import synchronize as _synchronize
     default=False,
     help="Adds a ``[skip ci]`` prefix to the commit message or not.",
 )
+@click.option(
+    "--random-branch-name",
+    is_flag=True,
+    default=False,
+    help="For testing purposes ONLY - generates a random branch name instead of the typical ``sync/file-sync``.",
+)
 def synchronize(
-    owner, repository, token, from_dir, to_dir, branch_checked_out, manifest, dry_run, skip_ci
+    owner,
+    repository,
+    token,
+    from_dir,
+    to_dir,
+    branch_checked_out,
+    manifest,
+    dry_run,
+    skip_ci,
+    random_branch_name,
 ):
     """CLI command to execute the repository synchronization."""
     _synchronize(
@@ -59,6 +74,7 @@ def synchronize(
         manifest=manifest,
         dry_run=dry_run,
         skip_ci=skip_ci,
+        random_branch_name=random_branch_name,
     )
 
 

--- a/src/ansys/tools/repo_sync/repo_sync.py
+++ b/src/ansys/tools/repo_sync/repo_sync.py
@@ -17,6 +17,7 @@ def synchronize(
     manifest: Optional[str] = None,
     dry_run: bool = False,
     skip_ci: bool = False,
+    random_branch_name: bool = False,
 ):
     """Synchronize a folder to a remote repository.
 
@@ -40,11 +41,19 @@ def synchronize(
         Simulate the behavior of the synchronization without performing it, by default ``False``.
     skip_ci : bool, optional
         Whether to add a ``[skip ci]`` prefix to the commit message or not. By default ``False``.
+    random_branch_name : bool, optional
+        For testing purposes - generates a random suffix for the branch name ``sync/file-sync``.
 
     """
     # New branch name and PR title
     new_branch_name = "sync/file-sync"
     pr_title = "sync: file sync performed by ansys-tools-repo-sync"
+
+    # If requested, add random suffix
+    if random_branch_name:
+        from secrets import token_urlsafe
+
+        new_branch_name = f"{new_branch_name}-{token_urlsafe(16)}"
 
     # Authenticate with GitHub
     g = Github(auth=Auth.Token(token))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,7 @@ def check_files_in_pr(owner, repository, pull_request_url, list_of_files):
     )
 
 
-def get_pr_from_cli(owner, repository):
+def get_pr_from_cli(owner, repository, branch_name, stdout):
     """Auxiliary method to get the PR generated when using CLI tool."""
     # Authenticate with GitHub
     g = Github(auth=Auth.Token(TOKEN))
@@ -67,10 +67,18 @@ def get_pr_from_cli(owner, repository):
     # Pull request already exists
     prs = repo.get_pulls()
 
+    # Find the branch name
+    branch_name = "sync/file-sync"
+    elems = stdout.decode("utf-8").split(" ")
+    for elem in elems:
+        if "sync/file-sync-" in elem:
+            branch_name = elem.strip("'")
+            break
+
     # Find the associated PR (must be open...)
     associated_pull_request = None
     for pr in prs:
-        if pr.head.ref == "sync/file-sync":
+        if pr.head.ref == branch_name:
             associated_pull_request = pr
             break
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,7 @@ def check_files_in_pr(owner, repository, pull_request_url, list_of_files):
     )
 
 
-def get_pr_from_cli(owner, repository, branch_name, stdout):
+def get_pr_from_cli(owner, repository, stdout):
     """Auxiliary method to get the PR generated when using CLI tool."""
     # Authenticate with GitHub
     g = Github(auth=Auth.Token(TOKEN))

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -37,6 +37,7 @@ def test_synchronize():
             from_dir=from_dir,
             to_dir=to_dir,
             skip_ci=True,
+            random_branch_name=True,
         )
 
         # Assertions or validations
@@ -74,6 +75,7 @@ def test_synchronize_with_manifest():
             to_dir=to_dir,
             manifest=manifest,
             skip_ci=True,
+            random_branch_name=True,
         )
 
         # Assertions or validations
@@ -129,6 +131,7 @@ def test_synchronize_from_cli():
             "--to-dir",
             "src/ansys",
             "--skip-ci",
+            "--random-branch-name",
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -141,7 +144,7 @@ def test_synchronize_from_cli():
     print(completed_process.stderr)
 
     # Get the PR associated to the CLI
-    pr_url = get_pr_from_cli("ansys", "ansys-tools-repo-sync")
+    pr_url = get_pr_from_cli("ansys", "ansys-tools-repo-sync", completed_process.stdout)
 
     # Check that the proper modified files have been added
     list_of_files = ["src/ansys/api/test/v0/hello_world.py", "src/ansys/api/test/v0/test.proto"]
@@ -192,6 +195,7 @@ def test_synchronize_with_manifest_from_cli():
             "--manifest",
             "manifest.txt",
             "--skip-ci",
+            "--random-branch-name",
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -204,7 +208,7 @@ def test_synchronize_with_manifest_from_cli():
     print(completed_process.stderr)
 
     # Get the PR associated to the CLI
-    pr_url = get_pr_from_cli("ansys", "ansys-tools-repo-sync")
+    pr_url = get_pr_from_cli("ansys", "ansys-tools-repo-sync", completed_process.stdout)
 
     # Check that the proper modified files have been added
     list_of_files = ["src/ansys/api/test/v0/test.proto"]


### PR DESCRIPTION
As title says. This will allow for random branch names and unblock parallelization for testing on workflow. It could also be used by end users if they want to, but it is not intended